### PR TITLE
Fix Application Freeze by Dispatching DisplayLink Updates to Main Thread

### DIFF
--- a/notch-prompter/PrompterViewModel.swift
+++ b/notch-prompter/PrompterViewModel.swift
@@ -242,7 +242,9 @@ final class PrompterViewModel: ObservableObject {
                 CVDisplayLinkSetOutputCallback(l, { (_, _, _, _, _, userInfo) -> CVReturn in
                     let ref = Unmanaged<CADisplayLinkProxy>.fromOpaque(userInfo!).takeUnretainedValue()
                     let ts = CFAbsoluteTimeGetCurrent()
-                    ref.subject.send(ts)
+                    DispatchQueue.main.async {
+                        ref.subject.send(ts)
+                    }
                     return kCVReturnSuccess
                 }, UnsafeMutableRawPointer(Unmanaged.passUnretained(self).toOpaque()))
                 CVDisplayLinkStart(l)


### PR DESCRIPTION
This PR addresses a critical bug where the application would freeze, forcing users to force-quit via Activity Monitor.

The root cause was identified in PrompterViewModel.swift. The CVDisplayLink callback runs on a background thread, but it was directly sending values to a Combine subject that triggers UI updates. Updating the UI from a background thread is undefined behavior in macOS/iOS development and led to the main thread deadlock.

This fix wraps the subject emission in DispatchQueue.main.async to ensure all UI-related updates occur safely on the main thread.

Changes
PrompterViewModel.swift: Wrapped ref.subject.send(ts) inside DispatchQueue.main.async within the CVDisplayLink output callback.